### PR TITLE
Force the .dtach delete at start

### DIFF
--- a/init/80_start_rtorrent.sh
+++ b/init/80_start_rtorrent.sh
@@ -2,7 +2,7 @@
 
 # clear hanging .dtach file from previous session
 if [ -f "/detach_sess/.dtach" ]; then
-rm /detach_sess/.dtach
+rm -f /detach_sess/.dtach
 sleep 1s
 fi
 


### PR DESCRIPTION
Maybe it works now, but I think its better to force it since it should be headless.
