### PR TITLE
Custom themes, closes #36

### DIFF
--- a/root/etc/cont-init.d/20-config
+++ b/root/etc/cont-init.d/20-config
@@ -39,6 +39,16 @@ cp /config/php/php.ini /etc/php7/php.ini
 [[ ! -e /var/www/localhost/rutorrent ]] && ln -s \
 /usr/share/webapps/rutorrent /var/www/localhost/rutorrent
 
+# themes... place your themes in: /config/themes
+# requires restart to refresh
+find /usr/share/webapps/rutorrent/plugins/theme/themes/ \
+  -mindepth 1 -maxdepth 1 -type l -exec rm {} +
+for i in $(ls -1 /config/themes)
+do
+    ln -s "/config/themes/$i" \
+          "/usr/share/webapps/rutorrent/plugins/theme/themes/$i"
+done
+
 # delete lock file if exists
 [[ -e /config/rtorrent/rtorrent_sess/rtorrent.lock ]] && \
 	rm /config/rtorrent/rtorrent_sess/rtorrent.lock


### PR DESCRIPTION
## What it does

+ Enables adding custom themes by adding them to `/config/themes/`.
+ Closes #36 

### Technical details:

The themes are each symlinked from `/config/themes/` into `/usr/share/webapps/rutorrent/plugins/theme/themes/`, and thus, when adding another theme, the container must be restarted so that `20-config` can be rerun.

Another possible solution that could be taken is to expose a `VOLUME /themes` and then copy `/usr/share/webapps/rutorrent/plugins/theme/themes/*` into that volume in `Dockerfile` and then symlink `/usr/share/webapps/rutorrent/plugins/theme/themes -> /themes`. This solution does not do that.

I think my solution is sufficient since new themes are rarely if ever added.
I'll try to create a PR for the alternate solution.