### PR TITLE
Custom themes, closes #36 (No Restart)

### DIFF
--- a/root/etc/cont-init.d/20-config
+++ b/root/etc/cont-init.d/20-config
@@ -45,9 +45,8 @@ cp /config/php/php.ini /etc/php7/php.ini
 	rm /config/rtorrent/rtorrent_sess/rtorrent.lock
 
 # custom themes
-if [ ! -L /usr/share/webapps/rutorrent/plugins/theme/themes ] ; then
+[[ ! -L /usr/share/webapps/rutorrent/plugins/theme/themes ]] && \
 	cp -R /usr/share/webapps/rutorrent/plugins/theme/themes/* /config/themes/
-fi
 rm -rf /usr/share/webapps/rutorrent/plugins/theme/themes
 ln -s /config/themes /usr/share/webapps/rutorrent/plugins/theme/themes
 

--- a/root/etc/cont-init.d/20-config
+++ b/root/etc/cont-init.d/20-config
@@ -4,6 +4,7 @@
 mkdir -p \
 	/config{/log/nginx,/log/rtorrent,/log/rutorrent,/nginx,/php,/rtorrent/rtorrent_sess,/rutorrent/settings/users} \
 	/config/rutorrent/profiles{/settings,/torrents,/users,/tmp} \
+    /config/themes \
 	/downloads{/completed,/incoming,/watched} \
 	/run{/nginx,/php} \
 	/var/lib/nginx/tmp/client_body
@@ -42,6 +43,13 @@ cp /config/php/php.ini /etc/php7/php.ini
 # delete lock file if exists
 [[ -e /config/rtorrent/rtorrent_sess/rtorrent.lock ]] && \
 	rm /config/rtorrent/rtorrent_sess/rtorrent.lock
+
+# custom themes
+if [ ! -L /usr/share/webapps/rutorrent/plugins/theme/themes ] ; then
+    cp -R /usr/share/webapps/rutorrent/plugins/theme/themes/* /config/themes/
+fi
+rm -rf /usr/share/webapps/rutorrent/plugins/theme/themes
+ln -s /config/themes /usr/share/webapps/rutorrent/plugins/theme/themes
 
 # permissions
 chown abc:abc \

--- a/root/etc/cont-init.d/20-config
+++ b/root/etc/cont-init.d/20-config
@@ -4,7 +4,7 @@
 mkdir -p \
 	/config{/log/nginx,/log/rtorrent,/log/rutorrent,/nginx,/php,/rtorrent/rtorrent_sess,/rutorrent/settings/users} \
 	/config/rutorrent/profiles{/settings,/torrents,/users,/tmp} \
-    /config/themes \
+	/config/themes \
 	/downloads{/completed,/incoming,/watched} \
 	/run{/nginx,/php} \
 	/var/lib/nginx/tmp/client_body
@@ -46,7 +46,7 @@ cp /config/php/php.ini /etc/php7/php.ini
 
 # custom themes
 if [ ! -L /usr/share/webapps/rutorrent/plugins/theme/themes ] ; then
-    cp -R /usr/share/webapps/rutorrent/plugins/theme/themes/* /config/themes/
+	cp -R /usr/share/webapps/rutorrent/plugins/theme/themes/* /config/themes/
 fi
 rm -rf /usr/share/webapps/rutorrent/plugins/theme/themes
 ln -s /config/themes /usr/share/webapps/rutorrent/plugins/theme/themes


### PR DESCRIPTION
## What it does:

+ Enables adding custom themes by adding them to `/config/themes/`.
+ Closes #36 
+ Themes can be **added without container restart**, unlike #41 .

### Technical details:

+ **If** `/usr/share/webapps/rutorrent/plugins/theme/themes/` **is** a regular directory and **not a symlink**, its **contents are copied** over to `/config/themes`.
+ Then, `/usr/share/webapps/rutorrent/plugins/theme/themes/` **is removed**, irrespective of if it is a symlink or not.
+ A **symlink**  `/usr/share/webapps/rutorrent/plugins/theme/themes -> /config/themes` is created.

### Recommendations:

+ That this PR should be merged, and **NOT** #41 .
+ That this PR should be **squashed**.