### PR TITLE
Fix rtorrent shut down

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ peer_exchange = no
 
 ## Versions
 
++ **12.09.17:** Cleanly shut down rtorrent.
 + **28.05.17:** Fix permissions on secondary temp folder of nginx.
 + **26.05.17:** Rebase to alpine 3.6.
 + **03.05.17:** Fix log permissions.

--- a/root/etc/services.d/cron/run
+++ b/root/etc/services.d/cron/run
@@ -1,3 +1,3 @@
 #!/usr/bin/with-contenv bash
 
-/usr/sbin/crond -f -S -l 5 -c /etc/crontabs
+exec /usr/sbin/crond -f -S -l 5 -c /etc/crontabs

--- a/root/etc/services.d/fpm/run
+++ b/root/etc/services.d/fpm/run
@@ -1,3 +1,3 @@
 #!/usr/bin/with-contenv bash
-/usr/sbin/php-fpm7 -F -y /etc/php7/php-fpm.d/rutorrent.conf
+exec /usr/sbin/php-fpm7 -F -y /etc/php7/php-fpm.d/rutorrent.conf
 

--- a/root/etc/services.d/rutorrent/run
+++ b/root/etc/services.d/rutorrent/run
@@ -11,12 +11,4 @@ _term() {
 	rtorrent s6-setuidgid abc /usr/bin/rtorrent \
 	-n -o import=/config/rtorrent/rtorrent.rc &
 
-until [ -e "/config/rtorrent/rtorrent_sess/rtorrent.lock" ];
-do
-sleep 1s
-done
-
-rtorrent_pid=$(< /config/rtorrent/rtorrent_sess/rtorrent.lock cut -d '+' -f 2)
-tail -n 1 -f /config/log/rtorrent/rtorrent.log "$rtorrent_pid" &
-
 wait

--- a/root/etc/services.d/rutorrent/run
+++ b/root/etc/services.d/rutorrent/run
@@ -2,7 +2,7 @@
 
 _term() {
   echo "Caught SIGTERM signal!"
-  killall -TERM rtorrent tail 2>/dev/null
+  killall -TERM rtorrent 2>/dev/null
 }
 
 	trap _term SIGTERM

--- a/root/etc/services.d/rutorrent/run
+++ b/root/etc/services.d/rutorrent/run
@@ -1,8 +1,15 @@
 #!/usr/bin/with-contenv bash
 
+_term() {
+  echo "Caught SIGTERM signal!"
+  killall -TERM rtorrent tail 2>/dev/null
+}
+
+	trap _term SIGTERM
+
 	screen -D -m -S \
 	rtorrent s6-setuidgid abc /usr/bin/rtorrent \
-	-n -o import=/config/rtorrent/rtorrent.rc
+	-n -o import=/config/rtorrent/rtorrent.rc &
 
 until [ -e "/config/rtorrent/rtorrent_sess/rtorrent.lock" ];
 do
@@ -10,4 +17,6 @@ sleep 1s
 done
 
 rtorrent_pid=$(< /config/rtorrent/rtorrent_sess/rtorrent.lock cut -d '+' -f 2)
-tail -n 1 -f /config/log/rtorrent/rtorrent.log "$rtorrent_pid"
+tail -n 1 -f /config/log/rtorrent/rtorrent.log "$rtorrent_pid" &
+
+wait


### PR DESCRIPTION
Do we need the tail log in the service file? Or was it there just to keep the service script in the foreground. If it's needed for some reason, I can add it as a separate service, because in its current form, it gets in the way of trapping the sigterm and forwarding it to the rtorrent process.

fixes #58 
fixes #57 