### PR TITLE
This fixes #66 - Added --pid flag to tail command

### DIFF
--- a/root/etc/services.d/rutorrent/run
+++ b/root/etc/services.d/rutorrent/run
@@ -10,4 +10,4 @@ sleep 1s
 done
 
 rtorrent_pid=$(< /config/rtorrent/rtorrent_sess/rtorrent.lock cut -d '+' -f 2)
-tail -n 1 -f /config/log/rtorrent/rtorrent.log "$rtorrent_pid"
+tail -n 1 -f /config/log/rtorrent/rtorrent.log --pid "$rtorrent_pid"


### PR DESCRIPTION
The tail command currently errors out since it is missing the --pid flag. 

![error_flag_tail](https://user-images.githubusercontent.com/2237123/32691707-60722e50-c6d1-11e7-9194-83fe9099c75f.png)

