### PR TITLE
Allow running fpm as root

### DIFF
--- a/root/etc/services.d/fpm/run
+++ b/root/etc/services.d/fpm/run
@@ -1,3 +1,3 @@
 #!/usr/bin/with-contenv bash
-/usr/sbin/php-fpm7 -F -y /etc/php7/php-fpm.d/rutorrent.conf
+/usr/sbin/php-fpm7 --allow-to-run-as-root -F -y /etc/php7/php-fpm.d/rutorrent.conf
 


### PR DESCRIPTION
For one reason or another in my environment it is much easier to run this as root... Mostly due to permissions around my NAS system. This will allow people if they so dare to set the PUID to 0 and run this container.

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

