### PR TITLE
Include util-linux to include 'script'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN \
 	tar \
 	unrar \
 	unzip \
+	util-linux \
 	wget \
 	zip && \
  echo "**** install webui ****" && \


### PR DESCRIPTION
When using docker-compose there is no tty and thus the rtorrent screen session cannot be attached. A workaround is to execute `script /dev/null` in the terminal so this PR includes util-linux which includes the `script` binary.

See discussion here for more info: https://github.com/moby/moby/issues/30421