### PR TITLE
Fix copy command duplicating theme folder

### DIFF
--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -24,7 +24,7 @@ cp -pr /config/rutorrent/settings/* /app/rutorrent/conf/
 
 # copy over any plugins to the plugins folder
 [[ -e /config/plugins ]] && \
-	cp -R /config/plugins/ /app/rutorrent/plugins/
+	cp -R /config/plugins/ /app/rutorrent/
 
 # delete lock file if exists
 [[ -e /config/rtorrent/rtorrent_sess/rtorrent.lock ]] && \

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -20,7 +20,7 @@ cp -pr /config/rutorrent/settings/* /app/rutorrent/conf/
 
 # copy over any theme files to themes folder
 [[ -e /config/themes ]] && \
-	cp -R /config/themes/ /app/rutorrent/plugins/theme/themes/
+	cp -R /config/themes/ /app/rutorrent/plugins/theme/
 
 # copy over any plugins to the plugins folder
 [[ -e /config/plugins ]] && \


### PR DESCRIPTION
Copy command would copy `/config/themes` into ...`plugins/theme/themes/themes`, instead of just ...`plugins/theme/themes`

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

