### PR TITLE
update packages on install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY patches/ /defaults/patches/
 
 RUN \
  echo "**** install runtime packages ****" && \
- apk add --no-cache \
+ apk add --no-cache --upgrade \
 	bind-tools \
 	curl \
 	fcgi \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -15,7 +15,7 @@ COPY patches/ /defaults/patches/
 
 RUN \
  echo "**** install runtime packages ****" && \
- apk add --no-cache \
+ apk add --no-cache --upgrade \
 	bind-tools \
 	curl \
 	fcgi \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -15,7 +15,7 @@ COPY patches/ /defaults/patches/
 
 RUN \
  echo "**** install runtime packages ****" && \
- apk add --no-cache \
+ apk add --no-cache --upgrade \
 	bind-tools \
 	curl \
 	fcgi \


### PR DESCRIPTION
Bugfix for libcurl version mismatch and just generally a better practice given the minimal size of layer differences on the base image. 