### PR TITLE
update build and runtime deps for current version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ RUN \
  echo "**** install build packages ****" && \
  apk add --no-cache --virtual=build-dependencies \
 	g++ \
+	libffi-dev \
+	openssl-dev \
 	python3-dev && \
  echo "**** install runtime packages ****" && \
  apk add --no-cache --upgrade \
@@ -23,7 +25,9 @@ RUN \
 	ffmpeg \
 	geoip \
 	gzip \
+	libffi \
 	mediainfo \
+	openssl \
 	php7 \
 	php7-cgi \
 	php7-pear \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -14,6 +14,8 @@ RUN \
  echo "**** install build packages ****" && \
  apk add --no-cache --virtual=build-dependencies \
 	g++ \
+	libffi-dev \
+	openssl-dev \
 	python3-dev && \
  echo "**** install runtime packages ****" && \
  apk add --no-cache --upgrade \
@@ -23,7 +25,9 @@ RUN \
 	ffmpeg \
 	geoip \
 	gzip \
+	libffi \
 	mediainfo \
+	openssl \
 	php7 \
 	php7-cgi \
 	php7-pear \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -14,6 +14,8 @@ RUN \
  echo "**** install build packages ****" && \
  apk add --no-cache --virtual=build-dependencies \
 	g++ \
+	libffi-dev \
+	openssl-dev \
 	python3-dev && \
  echo "**** install runtime packages ****" && \
  apk add --no-cache --upgrade \
@@ -23,7 +25,9 @@ RUN \
 	ffmpeg \
 	geoip \
 	gzip \
+	libffi \
 	mediainfo \
+	openssl \
 	php7 \
 	php7-cgi \
 	php7-pear \

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **13.05.19:** - Add libffi and openssl.
 * **07.05.19:** - Add cloudscraper pip package.
 * **11.04.19:** - Fix warnings in webui by adding python3, procps and pip packages.
 * **23.03.19:** - Switching to new Base images, shift to arm32v7 tag.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -61,6 +61,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "13.05.19:", desc: "Add libffi and openssl." }
   - { date: "07.05.19:", desc: "Add cloudscraper pip package." }
   - { date: "11.04.19:", desc: "Fix warnings in webui by adding python3, procps and pip packages." }
   - { date: "23.03.19:", desc: "Switching to new Base images, shift to arm32v7 tag." }


### PR DESCRIPTION
Need these deps for python modules to build. libffi and openssl. 