### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,9 @@ Below are the instructions for updating containers:
   containrrr/watchtower \
   --run-once rutorrent
   ```
+
+**Note:** We do not endorse the use of Watchtower as a solution to automated updates of existing Docker containers. In fact we generally discourage automated updates. However, this is a useful tool for one-time manual updates of containers where you have forgotten the original parameters. In the long term, we highly recommend using Docker Compose.
+
 * You can also remove the old dangling images: `docker image prune`
 
 ## Building locally

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ If you are seeing this error `Caught internal_error: 'DhtRouter::get_tracker did
 
 ```shell
 dht = disable
-peer_exchange = no
+protocol.pex.set = 0
 ```
 
 If after updating you see an error about connecting to rtorrent in the webui,

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -47,7 +47,7 @@ app_setup_block: |
 
   ```shell
   dht = disable
-  peer_exchange = no
+  protocol.pex.set = 0
   ```
 
   If after updating you see an error about connecting to rtorrent in the webui,


### PR DESCRIPTION
`peer_exchange = ...` option has been long deprecated and was [removed](https://github.com/rakshasa/rtorrent/wiki/RPC-Migration-0.9) entirely in rTorrent v0.9.7.
If it's set it causes errors in rutorrent as mentioned in the Readme. The new way to disable it [according to the docs](https://rtorrent-docs.readthedocs.io/en/latest/cmd-ref.html#term-protocol-pex) is `protocol.pex.set = 0`


