### PR TITLE
Revert "Rebasing to Alpine 3.11"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lsiobase/nginx:3.11
+FROM lsiobase/nginx:3.10
 
 # set version label
 ARG BUILD_DATE

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM lsiobase/nginx:arm64v8-3.11
+FROM lsiobase/nginx:arm64v8-3.10
 
 # set version label
 ARG BUILD_DATE

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM lsiobase/nginx:arm32v7-3.11
+FROM lsiobase/nginx:arm32v7-3.10
 
 # set version label
 ARG BUILD_DATE

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -63,7 +63,6 @@ app_setup_block: |
 
 # changelog
 changelogs:
-  - { date: "19.12.19:", desc: "Rebasing to alpine 3.11." }
   - { date: "28.06.19:", desc: "Rebasing to alpine 3.10." }
   - { date: "20.05.19:", desc: "Shift to building from official releases instead of commits." }
   - { date: "13.05.19:", desc: "Add libffi and openssl." }


### PR DESCRIPTION
Reverts linuxserver/docker-rutorrent#141 due to newly introduced bugs
https://discourse.linuxserver.io/t/issues-with-rutorrent-docker-container-on-qnap/1180
https://github.com/linuxserver/docker-rutorrent/issues/149