### PR TITLE
Fix python deps for _cloudflare plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN \
 	php7-pear \
 	php7-zip \
 	procps \
+	py3-requests \
 	python3 \
 	rtorrent \
 	screen \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -36,6 +36,7 @@ RUN \
 	php7-pear \
 	php7-zip \
 	procps \
+	py3-requests \
 	python3 \
 	rtorrent \
 	screen \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -36,6 +36,7 @@ RUN \
 	php7-pear \
 	php7-zip \
 	procps \
+	py3-requests \
 	python3 \
 	rtorrent \
 	screen \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  --> 
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

We welcome all PR’s though this doesn’t guarantee it will be accepted.

## Description:
<!--- Describe your changes in detail -->
The _cloudflare plugin has the requirement not only for python but also deps that are installed along with `py3-pip`, namely the requests module.
This change ensures that the `py3-requests` package is installed to maintain the required dependencies.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
If the requests module is not present rutorrent will always launch with the following error in the frontend logs:
```
_cloudflare plugin: cloudscraper module can't be loaded in Python
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Installed the `py3-requests` package in the `latest` container and observed that the error no longer appears.

Also attempted to load the respective modules required for the `_cloudflare` plugin as follows:

**Before:**
```
root@02fe1a17a971:/# python3
Python 3.8.3 (default, May 15 2020, 01:53:50)
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> help('cfscrape')
problem in cfscrape - ModuleNotFoundError: No module named 'requests'

>>> help('cloudscraper')
problem in cloudscraper - ModuleNotFoundError: No module named 'requests'
```
**After:**
```
root@02fe1a17a971:/# python3
Python 3.8.3 (default, May 15 2020, 01:53:50)
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> help('cfscrape')
Help on package cfscrape:

NAME
    cfscrape - # -*- coding: utf-8 -*-

PACKAGE CONTENTS
    user_agents
...
```


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
n/a